### PR TITLE
修复服务名不准和过滤dubbo monitor报文

### DIFF
--- a/src/main/java/com/github/kristofa/brave/dubbo/DubboClientRequestAdapter.java
+++ b/src/main/java/com/github/kristofa/brave/dubbo/DubboClientRequestAdapter.java
@@ -4,7 +4,6 @@ import com.alibaba.dubbo.rpc.Invocation;
 import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.RpcContext;
 import com.github.kristofa.brave.*;
-import com.github.kristofa.brave.dubbo.support.DefaultServerNameProvider;
 import com.github.kristofa.brave.dubbo.support.DefaultSpanNameProvider;
 import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Endpoint;
@@ -17,50 +16,58 @@ import java.util.Collections;
  * Created by chenjg on 16/7/24.
  */
 public class DubboClientRequestAdapter implements ClientRequestAdapter {
-    private Invoker<?> invoker;
-    private Invocation invocation;
-    private final static DubboSpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
-    private final static DubboServerNameProvider serverNameProvider = new DefaultServerNameProvider();
+	private Invoker<?> invoker;
+	private Invocation invocation;
+	private final static DubboSpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
 
+	public DubboClientRequestAdapter(Invoker<?> invoker, Invocation invocation) {
+		this.invoker = invoker;
+		this.invocation = invocation;
+	}
 
-    public DubboClientRequestAdapter(Invoker<?> invoker, Invocation invocation) {
-        this.invoker = invoker;
-        this.invocation = invocation;
-    }
+	@Override
+	public String getSpanName() {
+		return spanNameProvider.resolveSpanName(RpcContext.getContext());
+	}
 
-    @Override
-    public String getSpanName() {
-        return spanNameProvider.resolveSpanName(RpcContext.getContext());
-    }
+	@Override
+	public void addSpanIdToRequest(@Nullable SpanId spanId) {
+		String application = RpcContext.getContext().getUrl()
+				.getParameter("application");
+		RpcContext.getContext().setAttachment("clientName", application);
+		if (spanId == null) {
+			if ("com.alibaba.dubbo.monitor.MonitorService"
+					.equalsIgnoreCase(RpcContext.getContext().getUrl()
+							.getParameter("interface")))
+				RpcContext.getContext().setAttachment("sampled", "1");
+			else
+				RpcContext.getContext().setAttachment("sampled", "0");
+		} else {
+			RpcContext.getContext().setAttachment("traceId",
+					IdConversion.convertToString(spanId.traceId));
+			RpcContext.getContext().setAttachment("spanId",
+					IdConversion.convertToString(spanId.spanId));
+			if (spanId.nullableParentId() != null) {
+				RpcContext.getContext().setAttachment("parentId",
+						IdConversion.convertToString(spanId.parentId));
+			}
+		}
+	}
 
-    @Override
-    public void addSpanIdToRequest(@Nullable SpanId spanId) {
-        String application = RpcContext.getContext().getUrl().getParameter("application");
-        RpcContext.getContext().setAttachment("clientName", application);
-        if (spanId == null) {
-            RpcContext.getContext().setAttachment("sampled", "0");
-        }else{
-            RpcContext.getContext().setAttachment("traceId", IdConversion.convertToString(spanId.traceId));
-            RpcContext.getContext().setAttachment("spanId", IdConversion.convertToString(spanId.spanId));
-            if (spanId.nullableParentId() != null) {
-                RpcContext.getContext().setAttachment("parentId", IdConversion.convertToString(spanId.parentId));
-            }
-        }
-    }
+	@Override
+	public Collection<KeyValueAnnotation> requestAnnotations() {
+		return Collections.singletonList(KeyValueAnnotation.create("url",
+				RpcContext.getContext().getUrl().toString()));
+	}
 
-    @Override
-    public Collection<KeyValueAnnotation> requestAnnotations() {
-        return Collections.singletonList(KeyValueAnnotation.create("url", RpcContext.getContext().getUrl().toString()));
-    }
-
-    @Override
-    public Endpoint serverAddress() {
-        InetSocketAddress inetSocketAddress = RpcContext.getContext().getRemoteAddress();
-        String ipAddr = RpcContext.getContext().getUrl().getIp();
-        String serverName = serverNameProvider.resolveServerName(RpcContext.getContext());
-        return Endpoint.create(serverName, IPConversion.convertToInt(ipAddr),inetSocketAddress.getPort());
-    }
-
-
+	@Override
+	public Endpoint serverAddress() {
+		InetSocketAddress inetSocketAddress = RpcContext.getContext()
+				.getRemoteAddress();
+		String ipAddr = RpcContext.getContext().getUrl().getIp();
+		String serverName = null;
+		return Endpoint.create(serverName, IPConversion.convertToInt(ipAddr),
+				inetSocketAddress.getPort());
+	}
 
 }

--- a/src/main/java/com/github/kristofa/brave/dubbo/DubboServerRequestAdapter.java
+++ b/src/main/java/com/github/kristofa/brave/dubbo/DubboServerRequestAdapter.java
@@ -5,7 +5,6 @@ import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.RpcContext;
 import com.github.kristofa.brave.*;
 import com.github.kristofa.brave.dubbo.support.DefaultClientNameProvider;
-import com.github.kristofa.brave.dubbo.support.DefaultServerNameProvider;
 import com.github.kristofa.brave.dubbo.support.DefaultSpanNameProvider;
 
 import static com.github.kristofa.brave.IdConversion.convertToLong;
@@ -25,7 +24,7 @@ public class DubboServerRequestAdapter  implements ServerRequestAdapter {
     private Invocation invocation;
     private ServerTracer serverTracer;
     private final static  DubboSpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
-    private final static  DubboClientNameProvider clientNameProvider = new DefaultClientNameProvider();
+    //private final static  DubboClientNameProvider clientNameProvider = new DefaultClientNameProvider();
 
 
 
@@ -63,7 +62,7 @@ public class DubboServerRequestAdapter  implements ServerRequestAdapter {
 
         String ipAddr = RpcContext.getContext().getUrl().getIp();
         InetSocketAddress inetSocketAddress = RpcContext.getContext().getRemoteAddress();
-        final String clientName = clientNameProvider.resolveClientName(RpcContext.getContext());
+        final String clientName = invocation.getAttachment("clientName");//clientNameProvider.resolveClientName(RpcContext.getContext());
 
         serverTracer.setServerReceived(IPConversion.convertToInt(ipAddr),inetSocketAddress.getPort(),clientName);
 


### PR DESCRIPTION
修复后效果:
2018/8/3 上午9:58:58		                Client Send	10.1.34.19 (demotest-consumer)
2018/8/3 上午9:58:58	86.000ms	        Server Receive	10.1.34.19 (demotest-provider)
2018/8/3 上午9:58:58	407.000ms	Server Send	10.1.34.19 (demotest-provider)
2018/8/3 上午9:58:58	424.000ms	Client Receive	10.1.34.19 (demotest-consumer)

![image](https://user-images.githubusercontent.com/34697867/43620655-70a161c8-9706-11e8-83fd-ba4d82443304.png)


![image](https://user-images.githubusercontent.com/34697867/43620670-83a04e24-9706-11e8-8507-9850eb8ef01c.png)

